### PR TITLE
Update .BI TLD definition

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -87,7 +87,7 @@
 .bf	NONE		# http://www.arce.bf/ http://www.onatel.bf/internet/domaine.htm
 .bg	whois.register.bg
 .bh	NONE		# www.inet.com.bh
-.bi	WEB https://whois.nic.bi/
+.bi	whois1.nic.bi
 .bj	whois.nic.bj
 #.bl
 .bm	WEB http://207.228.133.14/cgi-bin/lansaweb?procfun+BMWHO+BMWHO2+WHO


### PR DESCRIPTION
.BI TLD now has a WHOIS server.

See http://www.iana.org/domains/root/db/bi.html
