### PR TITLE
Update .CF TLD definition

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -105,7 +105,7 @@
 .ca	whois.cira.ca
 .cc	VERISIGN whois.nic.cc
 .cd	whois.nic.cd
-.cf	NONE		# was: WEB http://www.nic.cf/whois.php3
+.cf	whois.dot.cf
 .cg	WEB http://www.nic.cg/cgi-bin/whois.pl
 .ch	whois.nic.ch
 .ci	www.nic.ci


### PR DESCRIPTION
.CF TLD now has a WHOIS server.

See
- http://www.iana.org/domains/root/db/cf.html
- https://github.com/weppos/ianawhois/commit/1cd774fd676bc16233047787cc927697a3c59590
