### PR TITLE
Add CentralNic .IN.NET TLD server

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -13,6 +13,7 @@
 .gb.net	whois.centralnic.net
 .gr.com	whois.centralnic.net
 .hu.com	whois.centralnic.net
+.in.net	whois.centralnic.net
 .no.com	whois.centralnic.net
 .qc.com	whois.centralnic.net
 .ru.com	whois.centralnic.net


### PR DESCRIPTION
Add CentralNic whois server for .in.net, instead of asking Verisign
