### PR TITLE
Improving whois.conf manpage to reflect whois capabilities

### DIFF
--- a/whois.conf.5
+++ b/whois.conf.5
@@ -31,7 +31,9 @@ encoding (ACE) format.
 # Hangul Korean TLD
 .br
 \\.xn--3e0b707e$   whois.kr
+.br
 # Private whois server
+.br
 as[64512-65534]   whois.server.local
 
 .SH "FILES"


### PR DESCRIPTION
It's possible to add ASes in the whois.conf but this is not documented anywhere.

This commit adds an example in the manpage.
