### PR TITLE
Improving whois.conf manpage to reflect whois capabilities

### DIFF
--- a/whois.conf.5
+++ b/whois.conf.5
@@ -32,9 +32,11 @@ encoding (ACE) format.
 .br
 \\.xn--3e0b707e$   whois.kr
 .br
-# Private whois server
+# Private AS range 64000-64999
 .br
-as[64512-65534]   whois.server.local
+as64[0-9][0-9][0-9]   whois.server.local
+
+
 
 .SH "FILES"
 /etc/whois.conf


### PR DESCRIPTION
It's possible to add ASes in the whois.conf but this is not documented anywhere.

This commit adds an example in the manpage.
