### PR TITLE
Update Verisign disclaimer hiding

### DIFF
--- a/data.h
+++ b/data.h
@@ -48,6 +48,11 @@ const char *hide_strings[] = {
     "; This data is provided by domaindiscount24.com", "",
     "%% NOTICE: Access to this information is provided", "%% By submitting", /* bookmyname.com */
     "% NOTICE: Access to the domains information", "% this query", /* CORE */
+    "The Data in MarkMonitor.com's", "--", /* MarkMonitor */
+    "Corporation Service Company(c) (CSC)  The Trusted Partner", "Register your domain name at", /* CSC */
+    "The data in Networksolutions.com's", "By submitting this query", /* Networksolutions */
+    "% Copyright (c)2003 by Deutsche Telekom AG", "% DOMAIN full", /* Deutsche Telekom  */
+    "# Welcome to the OVH WHOIS Server", "# soumettant une", /* ovh */
 
     /* gTLDs */
     "Access to .AERO WHOIS information", "",


### PR DESCRIPTION
It seems that the TLD server disclaimer has been changed with the following addition:

```
NOTICE: The expiration date displayed in this record is the date the
registrar's sponsorship of the domain name registration in the registry is
currently set to expire. This date does not necessarily reflect the expiration
date of the domain name registrant's agreement with the sponsoring
registrar.  Users may consult the sponsoring registrar's Whois database to
view the registrar's reported date of expiration for this registration.
```

The patch hides it.
