### PR TITLE
Update Verisign disclaimer hiding

### DIFF
--- a/data.h
+++ b/data.h
@@ -29,7 +29,7 @@ const char *ripe_servers[] = {
 
 const char *hide_strings[] = {
     "NOTICE AND TERMS OF USE: You", "",				/* NetSol */
-    "TERMS OF USE: You are not", "",				/* crsnic */
+    "NOTICE: The expiration date", "reserves the right",	/* VeriSign */
     "The data in Register", "",				    /* Register.Com */
     "The Data in the Tucows", "RECORD DOES NOT",
     "The information in this whois database", "",		/* DOTSTER */


### PR DESCRIPTION
It seems that the TLD server disclaimer has been changed with the following addition:

```
NOTICE: The expiration date displayed in this record is the date the
registrar's sponsorship of the domain name registration in the registry is
currently set to expire. This date does not necessarily reflect the expiration
date of the domain name registrant's agreement with the sponsoring
registrar.  Users may consult the sponsoring registrar's Whois database to
view the registrar's reported date of expiration for this registration.
```

The patch hides it.
