### PR TITLE
Add charset for whois.lacnic.net

### DIFF
--- a/servers_charset_list
+++ b/servers_charset_list
@@ -62,4 +62,5 @@ whois.ua		utf-8
 whois.nic.org.uy	utf-8
 whois.nic.wf		utf-8
 whois.nic.yt		utf-8
+whois.lacnic.net	iso-8859-1
 


### PR DESCRIPTION
Can be tested with "whois AS262237" (check first address line)
