### PR TITLE
Force v4/v6 server lookup

### DIFF
--- a/whois.h
+++ b/whois.h
@@ -19,7 +19,7 @@ int hide_line(int *hiding, const char *const line);
 char *do_query(const int, const char *);
 char *query_crsnic(const int, const char *);
 char *query_afilias(const int, const char *);
-int openconn(const char *, const char *);
+int openconn(int, const char *, const char *);
 int connect_with_timeout(int, const struct sockaddr *, socklen_t, int);
 void usage(int error);
 void alarm_handler(int);
@@ -37,7 +37,8 @@ char *convert_6to4(const char *);
 char *convert_teredo(const char *);
 char *convert_inaddr(const char *);
 int handle_query(const char *server, const char *port,
-		   const char *qstring, const char *fstring);
+		   const char *qstring, const char *fstring,
+		   int sock_family);
 void split_server_port(const char *const input, char **server, char **port);
 
 


### PR DESCRIPTION
This commit adds support for forcing whois to use v4 or v6 when looking up the
whois-server. There is no special handling of the case where a server is
specified manually. I assume a user to be smart enough to know what he or she is
doing when the flags are used.

One use-case for this feature is as follows:

I am working with a testbed where we frequently use traceroute to fetch the
trace to different servers, and then whois is used to lookup unknown IP
addresses. The nodes in the testbed are connected to a multitude of networks,
some v4-only, some v6-only and most v4/v6.

Several of the v6 networks are, for some reason hidden inside the ISPs network,
unstable. v4, on the other hand, is stable accross all networks. Linux, when
getaddrinfo is used with AF_UNSPEC, prioritizes v6 when a domain name is
resolved. When connected to an unstable v6-network, whois takes at least 10
second (the default connect timeout) longer to finish than when forcing v4.