### PR TITLE
whois.tld.ee

### DIFF
--- a/servers_charset_list
+++ b/servers_charset_list
@@ -19,7 +19,7 @@ whois.nic.cz		utf-8
 whois.denic.de		utf-8
 whois.enum.denic.de	utf-8
 whois.dk-hostmaster.dk	utf-8		--charset=utf-8
-whois.eenet.ee		iso-8859-1
+whois.tld.ee		utf-8
 whois.eu		utf-8
 whois.fi		iso-8859-1
 whois.nic.fo		utf-8


### PR DESCRIPTION
whois.eenet.ee is deprecated, whois.tld.ee uses utf-8