### PR TITLE
Centralnic definition update

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -9,6 +9,8 @@
 .ar.com	whois.centralnic.net
 .br.com	whois.centralnic.net
 .cn.com	whois.centralnic.net
+.com.de whois.centralnic.net
+.com.se whois.centralnic.net
 .de.com	whois.centralnic.net
 .eu.com	whois.centralnic.net
 .gb.com	whois.centralnic.net

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -5,6 +5,7 @@
 # Elements in this list are matched against the end of the query.
 # "NIC?" means that I have not been able to find the registry.
 
+.ae.org	whois.centralnic.net
 .br.com	whois.centralnic.net
 .cn.com	whois.centralnic.net
 .de.com	whois.centralnic.net

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -18,7 +18,6 @@
 .gr.com	whois.centralnic.net
 .hu.com	whois.centralnic.net
 .hu.net	whois.centralnic.net
-.in.net	whois.centralnic.net
 .no.com	whois.centralnic.net
 .qc.com	whois.centralnic.net
 .ru.com	whois.centralnic.net
@@ -32,6 +31,11 @@
 .za.com	whois.centralnic.net
 .jpn.com whois.centralnic.net
 .web.com whois.centralnic.net
+.africa.com whois.centralnic.net
+.gr.com whois.centralnic.net
+.in.net whois.centralnic.net
+.us.org whois.centralnic.net
+.co.com whois.centralnic.net
 
 .com	VERISIGN whois.verisign-grs.com
 

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -6,6 +6,7 @@
 # "NIC?" means that I have not been able to find the registry.
 
 .ae.org	whois.centralnic.net
+.ar.com	whois.centralnic.net
 .br.com	whois.centralnic.net
 .cn.com	whois.centralnic.net
 .de.com	whois.centralnic.net

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -17,6 +17,7 @@
 .gb.net	whois.centralnic.net
 .gr.com	whois.centralnic.net
 .hu.com	whois.centralnic.net
+.hu.net	whois.centralnic.net
 .in.net	whois.centralnic.net
 .no.com	whois.centralnic.net
 .qc.com	whois.centralnic.net

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -15,9 +15,12 @@
 .eu.com	whois.centralnic.net
 .gb.com	whois.centralnic.net
 .gb.net	whois.centralnic.net
-.gr.com	whois.centralnic.net
 .hu.com	whois.centralnic.net
 .hu.net	whois.centralnic.net
+.jp.net whois.centralnic.net
+.jpn.com whois.centralnic.net
+.kr.com whois.centralnic.net
+.mex.com whois.centralnic.net
 .no.com	whois.centralnic.net
 .qc.com	whois.centralnic.net
 .ru.com	whois.centralnic.net
@@ -28,9 +31,8 @@
 .uk.net	whois.centralnic.net
 .us.com	whois.centralnic.net
 .uy.com	whois.centralnic.net
-.za.com	whois.centralnic.net
-.jpn.com whois.centralnic.net
-.web.com whois.centralnic.net
+.za.bz whois.centralnic.net
+.za.com whois.centralnic.net
 .africa.com whois.centralnic.net
 .gr.com whois.centralnic.net
 .in.net whois.centralnic.net


### PR DESCRIPTION
This PR contains an update to the Centralnic list of pseudo TLDs. I tried to split the changes into more commits so that each commit contains extra information about the suffixes (including in some cases an example you can use to validate the existence of the TLD).

The list matches the one published at https://github.com/publicsuffix/list which is validated by a Centralnic representative.

PS. I've seen that you used both tabs or spaces to separate the TLD from the whois server. Do you have any preference? Let me know if you want me to reformat the PR.
