### PR TITLE
Update .PRO TLD definition

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -57,7 +57,7 @@
 .museum	whois.museum
 .name	whois.nic.name
 .post	whois.dotpostregistry.net
-.pro	whois.dotproregistry.net
+.pro	whois.afilias.net
 .tel	whois.nic.tel
 .travel	whois.nic.travel
 .xxx	whois.nic.xxx


### PR DESCRIPTION
```diff
diff --git a/PRO b/PRO
index 8bc2969..a1761b8 100644
--- a/PRO
+++ b/PRO
@@ -38,12 +38,12 @@ nserver:      B2.PRO.AFILIAS-NST.ORG 199.182.40.1 2001:500:e1:0:0:0:0:1
 nserver:      C0.PRO.AFILIAS-NST.INFO 199.182.16.1 2001:500:d0:0:0:0:0:1
 nserver:      D0.PRO.AFILIAS-NST.ORG 199.182.17.1 2001:500:d1:0:0:0:0:1
 
-whois:        whois.dotproregistry.net
+whois:        whois.afilias.net
 
 status:       ACTIVE
 remarks:      Registration information: http://www.registry.pro/
 
 created:      2002-05-08
-changed:      2012-06-27
+changed:      2016-02-18
 source:       IANA
 ```

I was also able to verify it by running a `whois` command passing the new host explicitly. The old host doesn't seem to respond anymore (it just hangs).

