### PR TITLE
Fix IP address query bug introduced by recovered list

### DIFF
--- a/data.h
+++ b/data.h
@@ -108,8 +108,18 @@ struct ip_del {
 };
 
 const struct ip_del ip_assign[] = {
-#include "ip_del_recovered.h"
 #include "ip_del.h"
+    { 0, 0, NULL }
+};
+
+struct ip_del_recovered {
+    const unsigned long start;
+    const unsigned long end;
+    const char         *serv;
+};
+
+const struct ip_del_recovered ip_assign_recovered[] = {
+#include "ip_del_recovered.h"
     { 0, 0, NULL }
 };
 

--- a/whois.c
+++ b/whois.c
@@ -544,10 +544,16 @@ char *guess_server(const char *s)
 #else
     if ((ip = myinet_aton(s))) {
 #endif
-	for (i = 0; ip_assign[i].serv; i++)
-	    if ((ip & ip_assign[i].mask) == ip_assign[i].net)
-		return strdup(ip_assign[i].serv);
-	return strdup("\x05");		/* not in the unicast IPv4 space */
+        /* check if ip is in the recovered list */
+        for (i = 0; ip_assign_recovered[i].serv; i++)
+            if ((ip >= ip_assign_recovered[i].start) && ip <= ip_assign_recovered[i].end)
+                return strdup(ip_assign_recovered[i].serv);
+
+        for (i = 0; ip_assign[i].serv; i++)
+            if ((ip & ip_assign[i].mask) == ip_assign[i].net)
+                return strdup(ip_assign[i].serv);
+
+        return strdup("\x05");          /* not in the unicast IPv4 space */
     }
 
     /* check the TLDs list */


### PR DESCRIPTION
ip_del.h uses network and bitmask fields to determine server
ip_del_recovered.h uses start ip and end ip

These were being joined in a single array and the code to
determine the server was the same, even though the data type
was different.

This patch separates out the recovered list and adds the
correct checks to determine a match.
