### PR TITLE
Refer .jobs queries to the registrar

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -52,7 +52,7 @@
 .cat	whois.nic.cat
 .coop	whois.nic.coop
 .info	whois.afilias.net
-.jobs	whois.nic.jobs
+.jobs	VERISIGN whois.nic.jobs
 .mobi	whois.dotmobiregistry.net
 .museum	whois.museum
 .name	whois.nic.name


### PR DESCRIPTION
Tested with "uhg.jobs" and "optum.jobs".
