### PR TITLE
WHOIS .BM TLD server corrected

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -90,7 +90,7 @@
 .bi	whois1.nic.bi
 .bj	whois.nic.bj
 #.bl
-.bm	WEB http://www.bermudanic.bm/cgi-bin/lansaweb?procfun+BMWHO+BMWHO2+WHO
+.bm	whois.asaplatform.info
 .bn	whois.bnnic.bn
 .bo	whois.nic.bo
 #.bq


### PR DESCRIPTION
whois rg.bm
This TLD has no whois server, but you can access the whois database at
http://207.228.133.14/cgi-bin/lansaweb?procfun+BMWHO+BMWHO2+WHO

whois rg.bm -h whois.asaplatform.info
Domain Name: rg.bm
Registry Domain ID:
Registrar WHOIS Server: whois.asaplatform.info
Registrar URL: http://www.asaplatform.info
Updated Date:
Creation Date: 2003-01-07T00:00:00.000
Registrar Registration Expiration Date: 2017-01-07T00:00:00.000
Registrar: The Registry General, Government of Bermuda