### PR TITLE
new TLD .deloitte

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -124,6 +124,7 @@
 .cy	WEB http://www.nic.cy/nslookup/online_database.php
 .cz	whois.nic.cz
 .de	whois.denic.de
+.deloitte whois.nic.deloitte
 .dj	WEB http://www.nic.dj/whois.php
 .dk	whois.dk-hostmaster.dk
 .dm	whois.nic.dm


### PR DESCRIPTION
As per http://www.iana.org/domains/root/db/deloitte.html

example
whois nic.deloitte -h whois.nic.deloitte
Domain Name: nic.deloitte
Domain ID: D1_DELOITTE-NCCGROUP
WHOIS Server: whois.nic.deloitte
