### PR TITLE
Fix  warnings and update fi.po

### DIFF
--- a/data.h
+++ b/data.h
@@ -4,7 +4,7 @@
  */
 
 /* servers which accept the new syntax (-V XXn.n) */
-const char *ripe_servers[] = {
+static const char *ripe_servers[] = {
     "whois.ripe.net",
     "whois.apnic.net",
     "whois.afrinic.net",
@@ -21,7 +21,7 @@ const char *ripe_servers[] = {
     NULL
 };
 
-const char *hide_strings[] = {
+static const char *hide_strings[] = {
     "The data in Networksolutions.com's WHOIS database", NULL,
     /* Some registrars like .wang copied the first paragraph of this
      * disclaimer, so the detection here needs to be split in two parts. */
@@ -85,7 +85,7 @@ const char *hide_strings[] = {
     NULL, NULL
 };
 
-const char *nic_handles[] = {
+static const char *nic_handles[] = {
     "net-",	"whois.arin.net",
     "netblk-",	"whois.arin.net",
     "poem-",	"whois.ripe.net",
@@ -107,7 +107,7 @@ struct ip_del {
     const char         *serv;
 };
 
-const struct ip_del ip_assign[] = {
+static const struct ip_del ip_assign[] = {
 #include "ip_del_recovered.h"
 #include "ip_del.h"
     { 0, 0, NULL }
@@ -119,7 +119,7 @@ struct ip6_del {
     const char          *serv;
 };
 
-const struct ip6_del ip6_assign[] = {
+static const struct ip6_del ip6_assign[] = {
 #include "ip6_del.h"
     { 0, 0, NULL }
 };
@@ -130,7 +130,7 @@ struct as_del {
     const char          *serv;
 };
 
-const struct as_del as_assign[] = {
+static const struct as_del as_assign[] = {
 #include "as_del.h"
     { 0, 0, NULL }
 };
@@ -141,22 +141,22 @@ struct as32_del {
     const char         *serv;
 };
 
-const struct as32_del as32_assign[] = {
+static const struct as32_del as32_assign[] = {
 #include "as32_del.h"
     { 0, 0, NULL }
 };
 
-const char *new_gtlds[] = {
+static const char *new_gtlds[] = {
 #include "new_gtlds.h"
     NULL
 };
 
-const char *tld_serv[] = {
+static const char *tld_serv[] = {
 #include "tld_serv.h"
     NULL,	NULL
 };
 
-const char *nic_handles_post[] = {
+static const char *nic_handles_post[] = {
 #include "nic_handles.h"
     NULL,	NULL
 };

--- a/mkpasswd.c
+++ b/mkpasswd.c
@@ -123,7 +123,7 @@ static const struct crypt_method methods[] = {
 
 void generate_salt(char *const buf, const unsigned int len);
 void *get_random_bytes(const unsigned int len);
-void display_help(int error);
+void NORETURN display_help(int error);
 void display_version(void);
 void display_methods(void);
 
@@ -363,7 +363,8 @@ int main(int argc, char *argv[])
 void* get_random_bytes(const unsigned int count)
 {
     char *buf;
-    int fd, bytes_read;
+    int fd;
+    ssize_t bytes_read;
 
     buf = NOFAIL(malloc(count));
     fd = open(RANDOM_DEVICE, O_RDONLY);
@@ -436,7 +437,7 @@ void generate_salt(char *const buf, const unsigned int len)
 
 #endif /* RANDOM_DEVICE || HAVE_ARC4RANDOM_BUF */
 
-void display_help(int error)
+void NORETURN display_help(int error)
 {
     fprintf((EXIT_SUCCESS == error) ? stdout : stderr,
 	    _("Usage: mkpasswd [OPTIONS]... [PASSWORD [SALT]]\n"

--- a/mkpasswd.c
+++ b/mkpasswd.c
@@ -150,7 +150,7 @@ int main(int argc, char *argv[])
     /* prepend options from environment */
     argv = merge_args(getenv("MKPASSWD_OPTIONS"), argv, &argc);
 
-    while ((ch = GETOPT_LONGISH(argc, argv, "hH:m:5P:R:sS:V", longopts, 0))
+    while ((ch = GETOPT_LONGISH(argc, argv, "hH:m:5P:R:sS:V", longopts, NULL))
 	    > 0) {
 	switch (ch) {
 	case '5':

--- a/po/fi.po
+++ b/po/fi.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: whois 5.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-04-10 04:23+0200\n"
-"PO-Revision-Date: 2014-06-09 15:27-0000\n"
+"POT-Creation-Date: 2017-01-02 17:02+0000\n"
+"PO-Revision-Date: 2017-01-02 17:04+0000\n"
 "Last-Translator: Sami Kerola <kerolasa@iki.fi>\n"
 "Language-Team: \n"
 "Language: fi\n"
@@ -15,9 +15,9 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Poedit 1.6.4\n"
+"X-Generator: Poedit 1.8.11\n"
 
-#: ../whois.c:148
+#: ../whois.c:233
 #, c-format
 msgid ""
 "Version %s.\n"
@@ -28,28 +28,28 @@ msgstr ""
 "\n"
 "Lähetä bugiraportit osoitteeseen %s.\n"
 
-#: ../whois.c:202 ../whois.c:255 ../whois.c:261 ../whois.c:291
+#: ../whois.c:287 ../whois.c:340 ../whois.c:347 ../whois.c:384
 #, c-format
 msgid "Using server %s.\n"
 msgstr "Käytetään palvelinta %s.\n"
 
-#: ../whois.c:240
+#: ../whois.c:325
 msgid "This TLD has no whois server, but you can access the whois database at"
 msgstr "Tälla TLD:llä ei ole whois palvelinta, voit hakea tiedot osoitteesta"
 
-#: ../whois.c:245
+#: ../whois.c:330
 msgid "This TLD has no whois server."
 msgstr "Tälla TLD:llä ei ole whois palvelinta."
 
-#: ../whois.c:248
+#: ../whois.c:333
 msgid "No whois server is known for this kind of object."
 msgstr "Mikään whois palvelu ei tiedä kysyttyä tietoa."
 
-#: ../whois.c:251
+#: ../whois.c:336
 msgid "Unknown AS number or IP network. Please upgrade this program."
 msgstr "Tuntematon AS-numero tai IP-verkko. Päivitä tämä ohjelma."
 
-#: ../whois.c:267
+#: ../whois.c:354
 #, c-format
 msgid ""
 "\n"
@@ -60,7 +60,7 @@ msgstr ""
 "Kysytään IPv4 ulostuloa %s IPv6:n IPv4 avaruudesta.\n"
 "\n"
 
-#: ../whois.c:273
+#: ../whois.c:361
 #, c-format
 msgid ""
 "\n"
@@ -71,7 +71,7 @@ msgstr ""
 "Kysytään IPv4 ulostuloa %s Teredo IPv6 tunneliosoitetta.\n"
 "\n"
 
-#: ../whois.c:292
+#: ../whois.c:385
 #, c-format
 msgid ""
 "Query string: \"%s\"\n"
@@ -80,7 +80,7 @@ msgstr ""
 "Kysely: \"%s\"\n"
 "\n"
 
-#: ../whois.c:302
+#: ../whois.c:395
 #, c-format
 msgid ""
 "\n"
@@ -93,16 +93,16 @@ msgstr ""
 "Löytyi viittaus %s.\n"
 "\n"
 
-#: ../whois.c:344 ../whois.c:347
+#: ../whois.c:437 ../whois.c:440
 #, c-format
 msgid "Cannot parse this line: %s"
 msgstr "Ohjelma ei ymmärrä riviä: %s"
 
-#: ../whois.c:516
+#: ../whois.c:634
 msgid "Warning: RIPE flags used with a traditional server."
 msgstr "Varoitus: käytät RIPE valitsimia perinteiseen palvelimeen."
 
-#: ../whois.c:675 ../whois.c:773
+#: ../whois.c:804 ../whois.c:910
 msgid ""
 "Catastrophic error: disclaimer text has been changed.\n"
 "Please upgrade this program.\n"
@@ -110,26 +110,26 @@ msgstr ""
 "Katastrofaalinen virhe: lisenssiteksti on muuttunut.\n"
 "Päivita ohjelma.\n"
 
-#: ../whois.c:828
+#: ../whois.c:972
 #, c-format
 msgid "Host %s not found."
 msgstr "Palvelinta %s ei löydy."
 
-#: ../whois.c:838
+#: ../whois.c:982
 #, c-format
 msgid "%s/tcp: unknown service"
 msgstr "%s/tcp: tuntematon palvelu"
 
-#: ../whois.c:913
+#: ../whois.c:1057
 msgid "Timeout."
 msgstr "Aikakatkaisu."
 
-#: ../whois.c:919
+#: ../whois.c:1063
 #, c-format
 msgid "Interrupted by signal %d..."
 msgstr "Ohjelma keskeytyi signaaliin %d..."
 
-#: ../whois.c:1189
+#: ../whois.c:1385
 #, c-format
 msgid ""
 "Usage: whois [OPTION]... OBJECT...\n"
@@ -200,55 +200,55 @@ msgstr ""
 "-v TYYPPI              hae pitkämallinne objektille TYYPPI\n"
 ".q [versio|lähde|tyyppi]   hae erityisiä palvelin tietoja\n"
 
-#: ../mkpasswd.c:84
+#: ../mkpasswd.c:87
 msgid "standard 56 bit DES-based crypt(3)"
 msgstr "Standardi 56-bittinen DES-salaus katso crypt(3)"
 
-#: ../mkpasswd.c:165
+#: ../mkpasswd.c:174
 #, c-format
 msgid "Invalid method '%s'.\n"
 msgstr "Kelvoton metodi '%s'.\n"
 
-#: ../mkpasswd.c:174 ../mkpasswd.c:184
+#: ../mkpasswd.c:183 ../mkpasswd.c:195
 #, c-format
 msgid "Invalid number '%s'.\n"
 msgstr "Kelvoton numero '%s'.\n"
 
-#: ../mkpasswd.c:201
+#: ../mkpasswd.c:213
 #, c-format
 msgid "Try '%s --help' for more information.\n"
 msgstr "Käytä valitsinta '%s --help' lisätietojen saamiseen.\n"
 
-#: ../mkpasswd.c:242
+#: ../mkpasswd.c:254
 #, c-format
 msgid "Wrong salt length: %d byte when %d expected.\n"
 msgid_plural "Wrong salt length: %d bytes when %d expected.\n"
 msgstr[0] "Väärä suolan pituus: %d tavu, kun %d odotettiin.\n"
 msgstr[1] "Väärä suolan pituus: %d tavua, kun %d odotettiin.\n"
 
-#: ../mkpasswd.c:247
+#: ../mkpasswd.c:259
 #, c-format
 msgid "Wrong salt length: %d byte when %d <= n <= %d expected.\n"
 msgid_plural "Wrong salt length: %d bytes when %d <= n <= %d expected.\n"
 msgstr[0] "Väärä suolan pituus: %d tavu, kun %d <= n <= %d odotettiin.\n"
 msgstr[1] "Väärä suolan pituus: %d tavua, kun %d <= n <= %d odotettiin.\n"
 
-#: ../mkpasswd.c:256
+#: ../mkpasswd.c:268
 #, c-format
 msgid "Illegal salt character '%c'.\n"
 msgstr "Laiton merkki suolassa '%c'.\n"
 
-#: ../mkpasswd.c:306 ../mkpasswd.c:322
+#: ../mkpasswd.c:319 ../mkpasswd.c:335
 #, c-format
 msgid "Password: "
 msgstr "Salasana: "
 
-#: ../mkpasswd.c:340
+#: ../mkpasswd.c:353
 #, c-format
 msgid "Method not supported by crypt(3).\n"
 msgstr "Functio crypt(3) ei tue toimintoa.\n"
 
-#: ../mkpasswd.c:419
+#: ../mkpasswd.c:443
 #, c-format
 msgid ""
 "Usage: mkpasswd [OPTIONS]... [PASSWORD [SALT]]\n"
@@ -259,7 +259,7 @@ msgstr ""
 "Salaa SALASANA crypt(3) funktiolla.\n"
 "\n"
 
-#: ../mkpasswd.c:422
+#: ../mkpasswd.c:446
 #, c-format
 msgid ""
 "      -m, --method=TYPE     select method TYPE\n"
@@ -294,7 +294,7 @@ msgstr ""
 "\n"
 "Lähetä bugiraportit osoitteeseen %s.\n"
 
-#: ../mkpasswd.c:452
+#: ../mkpasswd.c:476
 #, c-format
 msgid "Available methods:\n"
 msgstr "Käytettävissä olevat toiminnot:\n"

--- a/utils.c
+++ b/utils.c
@@ -72,7 +72,7 @@ char **merge_args(char *args, char *argv[], int *argc)
 }
 
 /* Error routines */
-void err_sys(const char *fmt, ...)
+void NORETURN err_sys(const char *fmt, ...)
 {
     va_list ap;
 
@@ -83,7 +83,7 @@ void err_sys(const char *fmt, ...)
     exit(2);
 }
 
-void err_quit(const char *fmt, ...)
+void NORETURN err_quit(const char *fmt, ...)
 {
     va_list ap;
 

--- a/utils.c
+++ b/utils.c
@@ -46,7 +46,8 @@ char **merge_args(char *args, char *argv[], int *argc)
 {
     char *arg, *argstring;
     char **newargs = NULL;
-    unsigned int i, num_env = 0;
+    int i;
+    unsigned int num_env = 0;
 
     if (!args)
 	return argv;

--- a/utils.h
+++ b/utils.h
@@ -16,8 +16,10 @@
 /* Portability macros */
 #ifdef __GNUC__
 # define NORETURN __attribute__((noreturn))
+# define UNUSED __attribute__((unused))
 #else
 # define NORETURN
+# define UNUSED
 #endif
 
 #ifndef AI_IDN

--- a/utils.h
+++ b/utils.h
@@ -54,7 +54,7 @@
 void *do_nofail(void *ptr, const char *file, const int line);
 char **merge_args(char *args, char *argv[], int *argc);
 
-void err_quit(const char *fmt, ...) NORETURN;
-void err_sys(const char *fmt, ...) NORETURN;
+void NORETURN err_quit(const char *fmt, ...);
+void NORETURN err_sys(const char *fmt, ...);
 
 #endif

--- a/whois.c
+++ b/whois.c
@@ -61,15 +61,15 @@
 #endif
 
 /* Global variables */
-int sockfd, verb = 0;
+static int sockfd, verb = 0;
 
 #ifdef ALWAYS_HIDE_DISCL
-int hide_discl = HIDE_NOT_STARTED;
+static int hide_discl = HIDE_NOT_STARTED;
 #else
-int hide_discl = HIDE_DISABLED;
+static int hide_discl = HIDE_DISABLED;
 #endif
 
-const char *client_tag = IDSTRING;
+static const char *client_tag = IDSTRING;
 
 #ifndef HAVE_GETOPT_LONG
 extern char *optarg;
@@ -1133,7 +1133,7 @@ const char *is_new_gtld(const char *s)
 	if (in_domain(s, new_gtlds[i]))
 	    return new_gtlds[i];
 
-    return 0;
+    return NULL;
 }
 
 /*

--- a/whois.c
+++ b/whois.c
@@ -1233,7 +1233,7 @@ void split_server_port(const char *const input,
     }
 
     /* change the server name to lower case */
-    for (p = (char *) *server; *p && *p != '\0'; p++)
+    for (p = (char *) *server; *p; p++)
 	*p = tolower(*p);
 }
 
@@ -1269,7 +1269,7 @@ char *convert_6to4(const char *s)
     }
 
     new = malloc(sizeof("255.255.255.255"));
-    sprintf(new, "%d.%d.%d.%d", a >> 8, a & 0xff, b >> 8, b & 0xff);
+    sprintf(new, "%ud.%ud.%ud.%ud", a >> 8, a & 0xff, b >> 8, b & 0xff);
 #endif
 
     return new;
@@ -1299,7 +1299,7 @@ char *convert_teredo(const char *s)
     a ^= 0xffff;
     b ^= 0xffff;
     new = malloc(sizeof("255.255.255.255"));
-    sprintf(new, "%d.%d.%d.%d", a >> 8, a & 0xff, b >> 8, b & 0xff);
+    sprintf(new, "%ud.%ud.%ud.%ud", a >> 8, a & 0xff, b >> 8, b & 0xff);
 #endif
 
     return new;

--- a/whois.c
+++ b/whois.c
@@ -126,7 +126,8 @@ int main(int argc, char *argv[])
     int longindex;
 #endif
 
-    int ch, nopar = 0, fstringlen = 64;
+    int ch, nopar = 0;
+    size_t fstringlen = 64;
     const char *server = NULL, *port = NULL;
     char *qstring, *fstring;
     int ret;
@@ -1050,13 +1051,13 @@ int connect_with_timeout(int fd, const struct sockaddr *addr,
     return 0;
 }
 
-void alarm_handler(int signum)
+void NORETURN alarm_handler(int signum UNUSED)
 {
     close(sockfd);
     err_quit(_("Timeout."));
 }
 
-void sighandler(int signum)
+void NORETURN sighandler(int signum)
 {
     close(sockfd);
     err_quit(_("Interrupted by signal %d..."), signum);
@@ -1378,7 +1379,7 @@ int isasciidigit(const char c) {
 
 /* http://www.ripe.net/ripe/docs/databaseref-manual.html */
 
-void usage(int error)
+void NORETURN usage(int error)
 {
     fprintf((EXIT_SUCCESS == error) ? stdout : stderr, _(
 "Usage: whois [OPTION]... OBJECT...\n\n"

--- a/whois.h
+++ b/whois.h
@@ -42,6 +42,6 @@ void split_server_port(const char *const input, char **server, char **port);
 
 
 /* flags for RIPE-like servers */
-const char *ripeflags="abBcdFGKlLmMrRx";
-const char *ripeflagsp="gisTtvq";
+static const char *ripeflags="abBcdFGKlLmMrRx";
+static const char *ripeflagsp="gisTtvq";
 

--- a/whois.h
+++ b/whois.h
@@ -1,3 +1,5 @@
+#include "utils.h"
+
 /* 6bone referto: extension */
 #define REFERTO_FORMAT	"%% referto: whois -h %255s -p %15s %1021[^\n\r]"
 
@@ -21,9 +23,9 @@ char *query_crsnic(const int, const char *);
 char *query_afilias(const int, const char *);
 int openconn(const char *, const char *);
 int connect_with_timeout(int, const struct sockaddr *, socklen_t, int);
-void usage(int error);
-void alarm_handler(int);
-void sighandler(int);
+void NORETURN usage(int error);
+void NORETURN alarm_handler(int);
+void NORETURN sighandler(int);
 int japanese_locale(void);
 unsigned long myinet_aton(const char *);
 unsigned long asn32_to_long(const char *);


### PR DESCRIPTION
This pull has fixes to gcc and clang warnings, when compiled with all possible warning flags I know to turn on. I also did static analysis with smatch and cppcheck to find additional warnings and took care of them as well. Last change is a bit odd one for the pull, it's a revalidation of Finnish translation - so not strictly speaking part of warnings series but I cannot be asked to make separate pull about that.

http://smatch.sourceforge.net/
http://cppcheck.sourceforge.net/