### PR TITLE
Add code for libidn2 (IDNA 2008 + TR46 non-transitional)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,14 @@ ifdef LOCALEDIR
 DEFS += -DLOCALEDIR=\"$(BASEDIR)$(prefix)/share/locale\"
 endif
 
+ifdef HAVE_LIBIDN2
+whois_LDADD += -lidn2
+DEFS += -DHAVE_LIBIDN2
+else
 ifdef HAVE_LIBIDN
 whois_LDADD += -lidn
 DEFS += -DHAVE_LIBIDN
+endif
 endif
 
 ifdef HAVE_ICONV


### PR DESCRIPTION
Add code for libidn2 (IDNA 2008 + TR46 non-transitional)

Set HAVE_LIBIDN2 instead of HAVE_LIBIDN for IDNA2008/TR46.
With IDNA2003, german sharp s will be stranslated into ss.
Thus straße.de and strasse.de will result in the same whois lookup.
TR46 preprocessing also takes care for a few other things, like
decomposed Unicode characters.