### PR TITLE
Fix misspellings in IPv4 formatting string

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -1279,7 +1279,7 @@ char *convert_6to4(const char *s)
     }
 
     new = malloc(sizeof("255.255.255.255"));
-    sprintf(new, "%ud.%ud.%ud.%ud", a >> 8, a & 0xff, b >> 8, b & 0xff);
+    sprintf(new, "%u.%u.%u.%u", a >> 8, a & 0xff, b >> 8, b & 0xff);
 #endif
 
     return new;
@@ -1309,7 +1309,7 @@ char *convert_teredo(const char *s)
     a ^= 0xffff;
     b ^= 0xffff;
     new = malloc(sizeof("255.255.255.255"));
-    sprintf(new, "%ud.%ud.%ud.%ud", a >> 8, a & 0xff, b >> 8, b & 0xff);
+    sprintf(new, "%u.%u.%u.%u", a >> 8, a & 0xff, b >> 8, b & 0xff);
 #endif
 
     return new;


### PR DESCRIPTION
There is a  new bug preventing from querying 6to4 address in whois-5.12.15. This is a fix.