### PR TITLE
Fix CIDR notation queries with libidn2

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -1179,7 +1179,8 @@ char *normalize_domain(const char *dom)
 	if (NULL != strchr(domain_start, ':'))
             return ret;
 	if (idn2_lookup_ul(domain_start, &q, IDN2_NONTRANSITIONAL) != IDN2_OK)
-	    return ret;
+	    if (idn2_lookup_ul(domain_start, &q, IDN2_TRANSITIONAL) != IDN2_OK)
+	        return ret;
 #else
 	if (idna_to_ascii_lz(domain_start, &q, 0) != IDNA_SUCCESS)
 	    return ret;
@@ -1206,7 +1207,8 @@ char *normalize_domain(const char *dom)
 	if (NULL != strchr(ret, ':'))
             return ret;
 	if (idn2_lookup_ul(ret, &q, IDN2_NONTRANSITIONAL) != IDN2_OK)
-	    return ret;
+	    if (idn2_lookup_ul(ret, &q, IDN2_TRANSITIONAL) != IDN2_OK)
+	        return ret;
 #else
 	if (idna_to_ascii_lz(ret, &q, 0) != IDNA_SUCCESS)
 	    return ret;

--- a/whois.c
+++ b/whois.c
@@ -1172,6 +1172,12 @@ char *normalize_domain(const char *dom)
 	int prefix_len;
 
 #ifdef HAVE_LIBIDN2
+        /* skip CIDR notation */
+	if (NULL != strchr(domain_start, '/'))
+            return ret;
+	/* skip IPv6 */
+	if (NULL != strchr(domain_start, ':'))
+            return ret;
 	if (idn2_lookup_ul(domain_start, &q, IDN2_NONTRANSITIONAL) != IDN2_OK)
 	    return ret;
 #else
@@ -1193,6 +1199,12 @@ char *normalize_domain(const char *dom)
 	char *q;
 
 #ifdef HAVE_LIBIDN2
+        /* skip CIDR notation */
+	if (NULL != strchr(ret, '/'))
+            return ret;
+        /* skip IPv6 */
+	if (NULL != strchr(ret, ':'))
+            return ret;
 	if (idn2_lookup_ul(ret, &q, IDN2_NONTRANSITIONAL) != IDN2_OK)
 	    return ret;
 #else


### PR DESCRIPTION
Fixes #50
Fixes https://bugzilla.opensuse.org/show_bug.cgi?id=1026831

Tested with without IDN, libidn and libidn2. Does the right thing on the wire. Please check.