### PR TITLE
Update .museum, .id, .sb

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,8 +2,8 @@ Source: whois
 Section: net
 Priority: standard
 Maintainer: Marco d'Itri <md@linux.it>
-Standards-Version: 4.1.0
-Build-Depends: debhelper (>= 5), gettext, libidn11-dev
+Standards-Version: 4.1.1.1
+Rules-Requires-Root: no
 Vcs-Git: git://github.com/rfc1036/whois.git
 Vcs-Browser: https://github.com/rfc1036/whois
 

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -54,7 +54,7 @@
 .info	whois.afilias.net
 .jobs	VERISIGN whois.nic.jobs
 .mobi	whois.afilias.net
-.museum	whois.museum
+.museum	whois.nic.museum
 .name	whois.nic.name
 .post	whois.dotpostregistry.net
 .pro	whois.afilias.net
@@ -168,7 +168,7 @@
 .hr	whois.dns.hr
 .ht	whois.nic.ht
 .hu	whois.nic.hu
-.id	whois.pandi.or.id
+.id	whois.id
 .ie	whois.domainregistry.ie
 .il	whois.isoc.org.il
 .im	whois.nic.im
@@ -265,7 +265,7 @@
 .ru	whois.tcinet.ru
 .rw	whois.ricta.org.rw	# http://www.ricta.org.rw/
 .sa	whois.nic.net.sa
-.sb	whois.nic.sb
+.sb	whois.nic.net.sb
 .sc	whois2.afilias-grs.net		# www.nic.sc
 .sd	NONE		# http://wwe.domains.sd/
 .se	whois.iis.se


### PR DESCRIPTION
These whois servers for these TLDs differ from those mentioned on www.iana.org.

The new servers for .museum and .id return different results than the servers currently used. The change for .sb is just a new hostname for the same IP address.

https://www.iana.org/domains/root/db/museum.html
https://www.iana.org/domains/root/db/id.html
https://www.iana.org/domains/root/db/sb.html