### PR TITLE
Remove unused variables in get_random_bytes()

### DIFF
--- a/mkpasswd.c
+++ b/mkpasswd.c
@@ -364,17 +364,17 @@ int main(int argc, char *argv[])
 
 void* get_random_bytes(const unsigned int count)
 {
-    char *buf;
-    int fd;
-    ssize_t bytes_read;
+    char *buf = NOFAIL(malloc(count));
 
-    buf = NOFAIL(malloc(count));
 #if defined HAVE_ARC4RANDOM_BUF
     arc4random_buf(buf, count);
 #elif defined HAVE_GETENTROPY
     if (getentropy(buf, count) < 0)
 	perror("getentropy");
 #else
+    int fd;
+    ssize_t bytes_read;
+
     fd = open(RANDOM_DEVICE, O_RDONLY);
     if (fd < 0) {
 	perror("open(" RANDOM_DEVICE ")");


### PR DESCRIPTION
If getentropy() is available, GCC warns about unsused variables:

mkpasswd.c: In function ‘get_random_bytes’:
mkpasswd.c:369:13: warning: unused variable ‘bytes_read’ [-Wunused-variable]
     ssize_t bytes_read;
             ^~~~~~~~~~
mkpasswd.c:368:9: warning: unused variable ‘fd’ [-Wunused-variable]
     int fd;
         ^~

This patch fixes it.