### PR TITLE
Update the .biz & .info TLD server

### DIFF
--- a/new_gtlds_list
+++ b/new_gtlds_list
@@ -118,6 +118,7 @@ bike
 bing
 bingo
 bio
+biz
 black
 blackfriday
 blanco
@@ -513,6 +514,7 @@ immo
 immobilien
 industries
 infiniti
+info
 ing
 ink
 institute

--- a/new_gtlds_list
+++ b/new_gtlds_list
@@ -118,7 +118,6 @@ bike
 bing
 bingo
 bio
-biz
 black
 blackfriday
 blanco
@@ -514,7 +513,6 @@ immo
 immobilien
 industries
 infiniti
-info
 ing
 ink
 institute

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -49,10 +49,8 @@
 
 .aero	whois.aero
 .asia	whois.nic.asia
-.biz	whois.biz
 .cat	whois.nic.cat
 .coop	whois.nic.coop
-.info	whois.afilias.net
 .jobs	VERISIGN whois.nic.jobs
 .mobi	whois.afilias.net
 .museum	whois.nic.museum

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -49,8 +49,10 @@
 
 .aero	whois.aero
 .asia	whois.nic.asia
+.biz	whois.nic.cat
 .cat	whois.nic.cat
 .coop	whois.nic.coop
+.info	whois.nic.info
 .jobs	VERISIGN whois.nic.jobs
 .mobi	whois.afilias.net
 .museum	whois.nic.museum


### PR DESCRIPTION
the .biz and .info WHOIS server have changed 
use ```whois google.biz -h whois.biz.ua``` can't get respond
but ```whois google.biz -h whois.nic.biz``` work
same as .info

| TLD        | obsolete           | now|
| ------------- |:-------------:| -----:|
| .biz      | whois.biz.ua | whois.nic.biz |
| .info      | whois.afilias.net    |  whois.nic.info |


