### PR TITLE
.CL changed server to UTF-8 encoding

### DIFF
--- a/servers_charset_list
+++ b/servers_charset_list
@@ -13,7 +13,7 @@ whois.ax		iso-8859-1
 whois.registro.br	iso-8859-1
 whois.cira.ca		iso-8859-1
 whois.nic.ch		utf-8
-whois.nic.cl		iso-8859-1
+whois.nic.cl		utf-8
 whois.cnnic.cn		utf-8
 cwhois.cnnic.cn		utf-8
 whois.nic.cz		utf-8


### PR DESCRIPTION
Since last month whois.nic.cl uses UTF-8 encoding for .CL domain names.
For example:
$ whois ñandú.cl
%%
%% This is the NIC Chile Whois server (whois.nic.cl).
%%
%% Rights restricted by copyright.
%% See https://www.nic.cl/normativa/politica-publicacion-de-datos-cl.pdf
%%

Domain name: Ã±andÃº.cl
Registrant name: UNIVERSIDAD DE CHILE
Registrant organisation: 
Registrar name: NIC Chile
Registrar URL: https://www.nic.cl
Creation date: 2005-08-15 22:40:23 CLST
Expiration date: 2037-01-31 21:00:00 CLST
Name server: ns.Ã±andÃº.cl (200.27.115.5)
Name server: secundario.nic.cl

%%
%% For communication with domain contacts please use website.
%% See https://www.nic.cl/registry/Whois.do?d=Ã±andÃº.cl
%%
