### PR TITLE
Add more popular SLD in Russia

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -30,6 +30,7 @@
 
 .com	VERISIGN whois.verisign-grs.com
 
+.ru.net	whois.flexireg.net
 .za.net	whois.za.net
 .net	VERISIGN whois.verisign-grs.com
 
@@ -262,7 +263,10 @@
 .re	whois.nic.re
 .ro	whois.rotld.ro
 .rs	whois.rnids.rs
+.com.ru	whois.flexireg.net
 .edu.ru	whois.informika.ru
+.msk.ru	whois.flexireg.net
+.spb.ru	whois.flexireg.net
 .ru	whois.tcinet.ru
 .rw	whois.ricta.org.rw	# http://www.ricta.org.rw/
 .sa	whois.nic.net.sa

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -30,7 +30,6 @@
 
 .com	VERISIGN whois.verisign-grs.com
 
-.ru.net	whois.flexireg.net
 .za.net	whois.za.net
 .net	VERISIGN whois.verisign-grs.com
 


### PR DESCRIPTION
Add more popular SLD in Russia, stats available at https://flexireg.net/en/stat_info (more than 50k domains delegated).

TLD https://faitid.org/en

https://www.iana.org/assignments/epp-repository-ids/epp-repository-ids.xhtml#FAITID