### PR TITLE
Remove duplicate output "Using server" when config file used

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -283,8 +283,6 @@ int main(int argc, char *argv[])
 #ifdef CONFIG_FILE
     if (!server) {
 	server = match_config_file(qstring);
-	if (verb && server)
-	    printf(_("Using server %s.\n"), server);
     }
 #endif
 


### PR DESCRIPTION
Example:

```
whois --verbose ru.spb.ru
Using server whois.flexireg.net.
Using server whois.flexireg.net.
Query string: "ru.spb.ru"

% By submitting a query to Whois Service
% you agree to abide by the following terms of use:
% http://flexireg.net/whois-terms_of_use.html (in Russian)
% http://flexireg.net/whois-terms_of_use.en.html (in English)
% For more information on Whois status codes, please visit
% https://icann.org/epp

Domain Name: ru.spb.ru
Registry Domain ID:   20150513084609134032_f66fa90b0816f4fffeecc2541c7871cf_domain-FIR
Registrar WHOIS Server: whois.nic.ru
Registrar URL: nic.ru
Updated Date: 2016-05-05T20:32:03Z
Creation Date: 2015-05-13T08:46:09Z
Registry Expiry Date: 2025-05-13T08:46:09Z
Registrar: JSC "RU-CENTER"
Domain Status: ok https://icann.org/epp#ok
Registry Registrant ID: Personal data, can not be publicly disclosed according to applicable laws.
Registrant Name: Personal data, can not be publicly disclosed according to applicable laws.
Registrant Street: Personal data, can not be publicly disclosed according to applicable laws.
Registrant City: Personal data, can not be publicly disclosed according to applicable laws.
Registrant State/Province: Personal data, can not be publicly disclosed according to applicable laws.
Registrant Postal Code: Personal data, can not be publicly disclosed according to applicable laws.
Registrant Country: Personal data, can not be publicly disclosed according to applicable laws.
Registrant Phone: Personal data, can not be publicly disclosed according to applicable laws.
Registrant Email: Please check Registrar RDDS. Personal data, can not be publicly disclosed according to applicable laws.
Name Server: parking2.nic.ru
Name Server: parking1.nic.ru
DNSSEC: unsignedDelegation
>>> Last update of WHOIS database: 2019-01-31T10:55:35Z<<<
```