### PR TITLE
Change behavior, if config file not accessible

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -414,7 +414,7 @@ const char *match_config_file(const char *s)
 
     if ((fp = fopen(CONFIG_FILE, "r")) == NULL) {
 	if (errno != ENOENT)
-	    err_sys("Cannot open " CONFIG_FILE);
+	    perror("Cannot open " CONFIG_FILE);
 	return NULL;
     }
 


### PR DESCRIPTION
Now, if config file not accessible, whois fails:

```
user@debian:~$ whois org.ru
Cannot open /etc/whois.conf: Permission denied
```

But it`s not critical error, and i think we need only show error

```
user@debian:~$ ./whois org.ru
Cannot open /etc/whois.conf: Permission denied
% By submitting a query to RIPN's Whois Service
% you agree to abide by the following terms of use:
% http://www.ripn.net/about/servpol.html#3.2 (in Russian) 
% http://www.ripn.net/about/en/servpol.html#3.2 (in English).

domain:        ORG.RU
nserver:       a.dns-servers.net.ru.
nserver:       b.dns-servers.net.ru.
nserver:       d.dns-servers.net.ru.
nserver:       e.dns-servers.net.ru.
nserver:       f.dns-servers.net.ru.
state:         REGISTERED, DELEGATED, VERIFIED
org:           ANO "MSK-IX"
registrar:     RU-CENTER-RU
admin-contact: https://www.nic.ru/whois
created:       1997-07-10T13:04:39Z
paid-till:     2019-07-31T21:00:00Z
free-date:     2019-09-01
source:        TCI

Last updated on 2019-01-31T18:01:38Z
```