### PR TITLE
Make sx. hide string more specific

### DIFF
--- a/data.h
+++ b/data.h
@@ -72,7 +72,7 @@ const char *hide_strings[] = {
     "% The WHOIS service offered by EURid", "% of the database", /* eu */
     "Access to .IN WHOIS information", NULL,			/* in */
     "access to .in whois information", NULL,		/* in registar */
-    "%", NULL,	/* sx */
+    "% Use of CIRA's WHOIS service is governed by the Terms of Use in its Legal", NULL,	/* sx */
     "The Service is provided so that you may look", "We may discontinue",/*vu*/
     "NeuStar, Inc., the Registry Administrator for .US", NULL,
 


### PR DESCRIPTION
Commit caa27b0675e171fe85c043d0199bfe77fddb23b9 broke displaying
results for at. subdomains because "%" lines exists in their outputs.

This patch changes the sx. start hide string to be more specific on
the expense that sx. output will contain a single "%" line.

More thorough fix would require changing the hiding algorithm to
either require prefix for each hidden line or to bind the strings to
their respective domains or servers.

Fixes <https://github.com/rfc1036/whois/issues/84>.