### PR TITLE
Support ARIN CIDRized network queries

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -692,6 +692,9 @@ char *queryformat(const char *server, const char *flags, const char *query)
 	if (strncaseeq(query, "AS", 2) && isasciidigit(query[2])) {
 	    strcat(buf, "a ");
 	    strcat(buf, query + 2);
+	} else if (strchr(query, '/') && (myinet_aton(query) || strchr(query, ':'))) {
+	    strcat(buf, "r + ");
+	    strcat(buf, query);
 	} else if (myinet_aton(query) || strchr(query, ':')) {
 	    strcat(buf, "n + ");
 	    strcat(buf, query);


### PR DESCRIPTION
This supports the 'r' query method at whois.arin.net:

      r       CIDRized network space
