### PR TITLE
Update the .jobs TLD server

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -53,7 +53,7 @@
 .cat	whois.nic.cat
 .coop	whois.nic.coop
 .info	whois.afilias.net
-.jobs	VERISIGN whois.nic.jobs
+.jobs	whois.nic.jobs
 .mobi	whois.afilias.net
 .museum	whois.nic.museum
 .name	whois.nic.name


### PR DESCRIPTION
Hi,

The whois tld server whois.nic.jobs is now handled by Nominet UK and does not follow VERISIGN rules anymore. Thus we get a "Syntax error." when trying to get the whois from the current commit.

Modiyfing the line 
.jobs VERISIGN whois.nic.jobs 
by 
.jobs whois.nic.jobs
in the file tld_serv_list fix this issue