### PR TITLE
Add support for hiding the whois.auda.org.au disclaimer

### DIFF
--- a/data.h
+++ b/data.h
@@ -64,6 +64,7 @@ const char *hide_strings[] = {
 
     /* ccTLDs */
     "Access to CCTLD WHOIS information is provided", "",	/* Afilias */
+    "Afilias Australia Pty Ltd (Afilias), for itself and on behalf of .au", NULL, /* au */
     "This WHOIS information is provided", NULL,			/* as */
     "% The WHOIS service offered by DNS Belgium", "",		/* be */
     ".CO Internet, S.A.S., the Administrator", NULL,		/* co */


### PR DESCRIPTION
This branch adds support for hiding the Afilias Australia disclaimer that is shown at the end of results from whois.auda.org.au. This can be tested by running e.g. `whois -H aph.gov.au` with and without this patch applied.