### PR TITLE
config.h: fix uclibc build without NLS

### DIFF
--- a/config.h
+++ b/config.h
@@ -17,7 +17,7 @@
 # include <sys/param.h>
 #endif
 
-#ifdef __GLIBC__
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
 # define ENABLE_NLS
 #endif
 


### PR DESCRIPTION
uclibc defines `__GLIBC__` but doesn't always have NLS support resulting in the following build failure:

```
In file included from whois.h:1,
                 from whois.c:44:
utils.h:38:11: fatal error: libintl.h: No such file or directory
   38 | # include <libintl.h>
      |           ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/a9d1c9076345d94ac2f9a4008b8563c5a34f655e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>