### PR TITLE
update charset for .TR

### DIFF
--- a/servers_charset_list
+++ b/servers_charset_list
@@ -57,7 +57,7 @@ whois.sgnic.sg		utf-8
 whois.tld.sy		utf-8
 whois.thains.co.th	utf-8
 whois.ati.tn		utf-8
-whois.nic.tr		iso-8859-9
+whois.nic.tr		utf-8
 whois.twnic.net.tw	utf-8
 whois.biz.ua		utf-8
 whois.co.ua		utf-8


### PR DESCRIPTION
Output encoding for .TR whois servers changed on Sep 14th, 2022

![image](https://user-images.githubusercontent.com/702578/190462298-9a93aaab-177a-488b-9730-f97e19e7b202.png)
