### PR TITLE
Reflect whois.nic.tr's charset change

### DIFF
--- a/servers_charset_list
+++ b/servers_charset_list
@@ -57,7 +57,7 @@ whois.sgnic.sg		utf-8
 whois.tld.sy		utf-8
 whois.thains.co.th	utf-8
 whois.ati.tn		utf-8
-whois.nic.tr		iso-8859-9
+whois.nic.tr		utf-8
 whois.twnic.net.tw	utf-8
 whois.biz.ua		utf-8
 whois.co.ua		utf-8


### PR DESCRIPTION
nic.tr has recently (since Sep 14) completely hands from the Middle East Technical University to the Information and Communication Technologies Authority of Turkey.

It seems that during the technical transition between Sep 12-14, they also changed the character set they use for whois responses from ISO-8859-9 to UTF-8.