### PR TITLE
CH registry does not provide whois services anymore.

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -109,7 +109,7 @@
 .cd	NONE
 .cf	NONE
 .cg	NONE		# www.nic.cg
-.ch	whois.nic.ch
+.ch	WEB https://www.nic.ch/whois/
 .ci	whois.nic.ci
 .ck	NONE
 .cl	whois.nic.cl


### PR DESCRIPTION
Hi there,

When querying the .ch tld server it appears that whois.nic.ch does not provide a whois server anymore but a web version.

As it, please accept this modification in tld_serv_list

```
$ whois abuse.ch
Requests of this client are not permitted. Please use https://www.nic.ch/whois/ for queries.
```

Regards,
Olivier Hureau