### PR TITLE
.fr whois is not a RIPE server

### DIFF
--- a/data.h
+++ b/data.h
@@ -9,7 +9,6 @@ const char *ripe_servers[] = {
     "whois.apnic.net",
     "whois.afrinic.net",
     "rr.arin.net",		/* does not accept the old syntax */
-    "whois.nic.fr",
     "rr.level3.net",		/* 3.0.0a13 */
     "rr.ntt.net",
     "whois.tcinet.ru",


### PR DESCRIPTION
See also Debian bug #1021110