### PR TITLE
Update the .tv TLD server

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -312,7 +312,7 @@
 .to	whois.tonic.to
 .tr	whois.nic.tr
 .tt	WEB http://www.nic.tt/cgi-bin/search.pl
-.tv	VERISIGN tvwhois.verisign-grs.com
+.tv	whois.nic.tv
 .tw	whois.twnic.net.tw
 .tz	whois.tznic.or.tz
 .biz.ua	whois.biz.ua


### PR DESCRIPTION
Changed whois service from Verisign to GoDaddy, the new owner of the .tv ccTLD.

More information: https://domainnamewire.com/2021/12/14/godaddy-wins-contract-to-run-tv-verisign-didnt-bid-for-renewal/