### PR TITLE
Add bash completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,8 @@ endif
 
 CPPFLAGS += $(DEFS) $(INCLUDES)
 
+BASHCOMPDIR ?= $(shell $(PKG_CONFIG) --variable=completionsdir bash-completion 2>/dev/null || echo /etc/bash_completion.d)
+
 ##############################################################################
 all: Makefile.depend whois mkpasswd pos
 
@@ -121,7 +123,7 @@ afl-run:
 	nice afl-fuzz -i ../afl_in -o ../afl_out -- ./whois
 
 ##############################################################################
-install: install-whois install-mkpasswd install-pos
+install: install-whois install-mkpasswd install-pos install-bashcomp
 
 install-whois: whois
 	$(INSTALL) -d $(BASEDIR)$(prefix)/bin/
@@ -139,6 +141,11 @@ install-mkpasswd: mkpasswd
 
 install-pos:
 	cd po && $(MAKE) install
+
+install-bashcomp:
+	$(INSTALL) -d $(BASEDIR)$(BASHCOMPDIR)
+	$(INSTALL) -m 0644 mkpasswd.bash $(BASEDIR)$(BASHCOMPDIR)/mkpasswd
+	$(INSTALL) -m 0644 whois.bash $(BASEDIR)$(BASHCOMPDIR)/whois
 
 distclean: clean
 	rm -f version.h po/whois.pot

--- a/mkpasswd.bash
+++ b/mkpasswd.bash
@@ -1,0 +1,33 @@
+_mkpasswd() {
+
+	case $3 in
+	--help | --version | --salt | --rounds | --password-fd | -[hVSRP])
+		return 0
+		;;
+	--method | -m)
+		COMPREPLY=($(compgen -W '$(
+			LC_ALL=C "$1" --method=help 2>/dev/null |
+				while read -r method _; do
+					[[ $method == Available ]] ||
+						printf "%s\n" "$method"
+				done
+			)'))
+		return 0
+		;;
+	esac
+
+	if [[ $2 == -* ]]; then
+		COMPREPLY=($(compgen -W '
+			--method
+			-5
+			--salt
+			--rounds
+			--password-fd
+			--stdin
+			--help
+			--version
+		' -- "$2"))
+		return 0
+	fi
+
+} && complete -F _mkpasswd mkpasswd

--- a/whois.bash
+++ b/whois.bash
@@ -1,0 +1,86 @@
+_whois_query() {
+	"$1" -q "$2" 2>/dev/null | while read -r item _; do
+		[[ $item == %* ]] && continue
+		printf "%s\n" "${item%%:*}"
+	done
+}
+
+_whois_hosts() {
+	# _known_hosts_real from github.com/scop/bash-completion if available
+	if declare -f _known_hosts_real &>/dev/null; then
+		_known_hosts_real -- "$1"
+		return 0
+	fi
+	COMPREPLY=($(compgen -A hostname -- "$1"))
+}
+
+_whois() {
+
+	case $3 in
+	--help | --version | -p | --port | -i)
+		return 0
+		;;
+	-h | --host)
+		_whois_hosts "$2"
+		return 0
+		;;
+	-T | -t | -v)
+		[[ ${_whois_types-} ]] ||
+			_whois_types=" $(_whois_query "$1" types)"
+		COMPREPLY=($(compgen -W '$_whois_types' -- "$2"))
+		return 0
+		;;
+	-s | -g)
+		[[ ${_whois_sources-} ]] ||
+			_whois_sources=" $(_whois_query "$1" sources)"
+		COMPREPLY=($(compgen -W '$_whois_sources' -- "$2"))
+		if [[ $3 == -g ]]; then
+			[[ ${#COMPREPLY[*]} -eq 1 ]] && COMPREPLY[0]+=:
+			compopt -o nospace
+		fi
+		return 0
+		;;
+	-q)
+		COMPREPLY=($(compgen -W 'version sources types' -- "$2"))
+		return 0
+		;;
+	esac
+
+	if [[ $2 == -* ]]; then
+		COMPREPLY=($(compgen -W '
+			-h --host
+			-p --port
+			-I
+			-H
+			--verbose
+			--no-recursion
+			--help
+			--version
+			-l
+			-L
+			-m
+			-M
+			-c
+			-x
+			-b
+			-B
+			-G
+			-d
+			-i
+			-T
+			-K
+			-r
+			-R
+			-a
+			-s
+			-g
+			-t
+			-v
+			-q
+		' -- "$2"))
+		return 0
+	fi
+
+	_whois_hosts "$2"
+
+} && complete -F _whois whois


### PR DESCRIPTION
This adds bash completions for whois and mkpasswd. They're standalone and have quite basic functionality, some more could be added but in that case I'd suggest making them dependent on https://github.com/scop/bash-completion. In particular, option arguments split with the equals sign are not supported; whitespace separated are.

The mkpasswd completion does not offer short completions where long ones exist. The reasoning for this is outlined in https://github.com/scop/bash-completion/blob/5927d5733be672268ae15e78fd3b1a5d91cfbc2d/CONTRIBUTING.md?plain=1#L128-L145
Note that this is only about the option names; completing arguments to short ones, if given by user, are supported where available.
The whois completion does offer the short ones even for the few that have long ones, because almost all options to it are short ones anyway.