### PR TITLE
Update .kg NIC handle server

### DIFF
--- a/nic_handles_list
+++ b/nic_handles_list
@@ -8,7 +8,7 @@
 -dk	whois.dk-hostmaster.dk
 -il	whois.isoc.org.il
 -is	whois.isnic.is
--kg	whois.domain.kg
+-kg	whois.kg
 -coop	whois.nic.coop
 -frnic	whois.nic.fr
 -lrms	whois.afilias.info

--- a/servers_charset_list
+++ b/servers_charset_list
@@ -38,7 +38,7 @@ whois.isnic.is		iso-8859-1
 whois.nic.it		utf-8
 whois.jprs.jp		iso-2022-jp
 whois.nic.ad.jp		iso-2022-jp
-whois.domain.kg		cp1251
+whois.kg		cp1251
 whois.nic.or.kr		utf-8
 whois.kr		utf-8
 whois.nic.kz		utf-8


### PR DESCRIPTION
Meanwhile "whois.domain.kg" became "whois.kg" (and only latter is reachable nowadays).