### PR TITLE
Add the .com.de TLD server

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -132,6 +132,7 @@
 .cx	whois.nic.cx
 .cy	WEB https://www.nic.cy/cy-ui/home
 .cz	whois.nic.cz
+.com.de	whois.centralnic.net	# "unofficial" SLD
 .de	whois.denic.de
 .dj	NONE		# http://www.dj/
 .dk	whois.dk-hostmaster.dk

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -364,7 +364,7 @@
 .net.za	net-whois.registry.net.za
 .org.za	org-whois.registry.net.za
 .web.za	web-whois.registry.net.za
-.za	NONE		# http://www.zadna.org.za/content/page/domain-information
+.za	NONE		# https://www.nic.za/za-domains/
 .zm	whois.zicta.zm
 .zw	NONE		# http://www.zispa.co.zw/
 

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -357,7 +357,7 @@
 .ye	NONE		# NIC? http://www.y.net.ye/services/domain_name.htm
 .yt	whois.nic.yt
 .ac.za	whois.ac.za
-.alt.za	whois.alt.za
+.alt.za	WEB https://whois.alt.za/
 .co.za	whois.registry.net.za
 .gov.za	whois.gov.za
 .net.za	net-whois.registry.net.za

--- a/tld_serv_list
+++ b/tld_serv_list
@@ -359,6 +359,7 @@
 .ac.za	whois.ac.za
 .alt.za	WEB https://whois.alt.za/
 .co.za	whois.registry.net.za
+.edu.za	WEB https://whois.edu.za/
 .gov.za	whois.gov.za
 .net.za	net-whois.registry.net.za
 .org.za	org-whois.registry.net.za


### PR DESCRIPTION
This is an unofficial SLD, quoting their [FAQs](https://com.de/faqs/):
> ComdeRegistry owns the .com.de SLD, and has partnered with global leading domain name registry CentralNic to manage the domain’s operation.