### PR TITLE
Add SPDX license identifiers to code files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0-or-later
 prefix = /usr
 
 ifdef DESTDIR

--- a/config.h
+++ b/config.h
@@ -1,4 +1,5 @@
 /* Configurable features */
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 /* Always hide legal disclaimers */
 #undef ALWAYS_HIDE_DISCL

--- a/make_as32_del.pl
+++ b/make_as32_del.pl
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use warnings;
 use strict;

--- a/make_as_del.pl
+++ b/make_as_del.pl
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use warnings;
 use strict;

--- a/make_ip_del.pl
+++ b/make_ip_del.pl
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use warnings;
 use strict;

--- a/make_new_gtlds.pl
+++ b/make_new_gtlds.pl
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use warnings;
 use strict;

--- a/make_nic_handles.pl
+++ b/make_nic_handles.pl
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use warnings;
 use strict;

--- a/make_servers_charset.pl
+++ b/make_servers_charset.pl
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use warnings;
 use strict;

--- a/make_tld_serv.pl
+++ b/make_tld_serv.pl
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use warnings;
 use strict;

--- a/make_version_h.pl
+++ b/make_version_h.pl
@@ -1,4 +1,5 @@
 #!/usr/bin/perl
+# SPDX-License-Identifier: GPL-2.0-or-later
 
 use warnings;
 use strict;

--- a/mkpasswd.1
+++ b/mkpasswd.1
@@ -90,4 +90,5 @@ This program suffers of a bad case of featuritis.
 and this man page were written by Marco d'Itri
 .RI < md@linux.it >
 and are licensed under the terms of the GNU General Public License,
-version 2 or higher.
+version 2 or later.
+\" SPDX-License-Identifier: GPL-2.0-or-later

--- a/mkpasswd.c
+++ b/mkpasswd.c
@@ -14,6 +14,8 @@
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 /* for crypt, snprintf and strcasecmp */

--- a/utils.h
+++ b/utils.h
@@ -1,5 +1,6 @@
 #ifndef WHOIS_UTILS_H
 #define WHOIS_UTILS_H
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 
 /* Convenience macros */
 #define streq(a, b) (strcmp(a, b) == 0)

--- a/whois.1
+++ b/whois.1
@@ -304,5 +304,5 @@ original BSD client.
 and this man page were written by Marco d'Itri
 .RI < md@linux.it >
 and are licensed under the terms of the GNU General Public License,
-version 2 or higher.
-
+version 2 or later.
+\" SPDX-License-Identifier: GPL-2.0-or-later

--- a/whois.c
+++ b/whois.c
@@ -5,6 +5,8 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 2 of the License, or
  * (at your option) any later version.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
 /* for AI_IDN */

--- a/whois.conf.5
+++ b/whois.conf.5
@@ -47,3 +47,4 @@ This manual page was written by Petr Písař
 .RI < ppisar@redhat.com >
 and is licensed under the terms of the GNU General Public License,
 version 2 or higher.
+\" SPDX-License-Identifier: GPL-2.0-or-later

--- a/whois.h
+++ b/whois.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
 #include "utils.h"
 
 /* 6bone referto: extension */


### PR DESCRIPTION
Change manual pages word to recognize it by licensecheck tool.