### PR TITLE
Support APNIC inter-RIR IPv4 transfer whois referrals

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -808,6 +808,23 @@ char *do_query(const int sock, const char *query)
 		*p = '\0';
 	}
 
+        /*APNIC referrals and Inter-RIR transfers:
+         * descr: Transferred to the RIPE region on 2023-08-17T09:45:47Z.
+         * descr: Transferred to the ARIN region on 2023-08-17T09:45:47Z.
+         */
+        if (!referral_server && strneq(buf, "descr:", 6)) {
+            if ((p = strstr(buf, "Transferred to the RIPE region")))
+                referral_server = "whois.ripe.net";
+            else if ((p = strstr(buf, "Transferred to the ARIN region")))
+                referral_server = "whois.arine.net";
+            else if ((p = strstr(buf, "Transferred to the LACNIC region")))
+                referral_server = "whois.lacnic.net";
+            else if ((p = strstr(buf, "Transferred to the AFRINIC region")))
+                referral_server = "whois.afrinic.net";
+            if (referral_server && (p = strpbrk(referral_server, "/\r\n")))
+                *p = '\0';
+        }
+
 	if (hide_line(&hide, buf))
 	    continue;
 


### PR DESCRIPTION
Fixes #95 

With a rapidly growing amount of inter-RIR transfers FROM the APNIC region to other RIRs (ARIN/RIPE/LACNIC, and probably soon to be Afrinic) its not feasible to manage the list of changing IPs manually, instead we will use the whois server referral system instead for correct queries.

Some examples:

APNIC -> RIPE 
Example: 103.251.164.0/22

APNIC -> ARIN
Example: 103.11.64.0/22

APNIC -> LACNIC 
Example: 103.212.83.0/24

APNIC -> Afrinic
(Inter-RIR transfers are not support yet, but still programmed in for when and if its supported one day)