### PR TITLE
Fix build with Clang

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -17,7 +17,11 @@
 /* Portability macros */
 #ifdef __GNUC__
 # define NORETURN __attribute__((noreturn))
+#ifndef __clang__
 # define MALLOC_FREE __attribute__((malloc(free)))
+#else
+# define MALLOC_FREE
+#endif
 # define NONNULL __attribute__((returns_nonnull))
 #else
 # define NORETURN


### PR DESCRIPTION
Clang defines the `__GNUC__` macro, but it doesn't implement the `malloc (deallocator)` attribute.
Fixes https://github.com/rfc1036/whois/issues/155