### PR TITLE
fix: support malloc without arguments on clang

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -15,7 +15,11 @@
 #endif
 
 /* Portability macros */
-#ifdef __GNUC__
+#ifdef __clang__
+# define NORETURN __attribute__((noreturn))
+# define MALLOC_FREE __attribute__((malloc))
+# define NONNULL __attribute__((returns_nonnull))
+#elif __GNUC__
 # define NORETURN __attribute__((noreturn))
 # define MALLOC_FREE __attribute__((malloc(free)))
 # define NONNULL __attribute__((returns_nonnull))


### PR DESCRIPTION
Current HEAD fails to compile on clang systems, both with glibc and with musl, due to commit f01f8d4:

./utils.h:62:7: error: 'malloc' attribute takes no arguments

I'm not sure my solution is the cleanest, but it works on my machines.

