### PR TITLE
Only use attribute with GCC 11 & up

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -24,7 +24,7 @@
 # define NONNULL
 # define UNUSED
 #endif
-#if defined __GNUC__ && !defined __clang__
+#if (defined __GNUC__ && __GNUC__ >= 11) && !defined __clang__
 # define MALLOC_FREE __attribute__((malloc(free)))
 #else
 # define MALLOC_FREE


### PR DESCRIPTION
__attribute__((malloc(free))) was introduced in GCC 11. Build breaks with older toolchains.
With this change, it is possible to compile whois with GCC 4.0.