### PR TITLE
Fix memory leak in whois.c

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -409,7 +409,7 @@ int handle_query(const char *hserver, const char *hport,
     }
 
     sockfd = openconn(server, port);
-
+    free(server);
     server = do_query(sockfd, query_string);
     free(query_string);
 


### PR DESCRIPTION
Hi, I am a new contributor to this repository :). I came across the open issue #165  which is a leaksanitizer report about a leak that happens on  `./whois 64.233.165.113`. I was able to reproduce the bug on running the command and was able to generate a patch for it. The leak happens within functions `handle_query`  when `server` is reassigned with return value of `do_query` without freeing. Note that at this point `server` must have a non Null value because a Null check exists earlier in the code.

I have verified that after the patch, the leak no longer occurs through leaksanitizer (and there is no double free for that matter).

Please let me know if the patch is useful :)