### PR TITLE
`mkpasswd`: Add `--prompts=NUMBER` parameter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+tab_width = 8
+
+[*.{c,h}]
+indent_style = tab
+indent_size = 4
+
+[*.{pl,bash}]
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
If you are an inaccurate typist like me, you probably want to type your password multiple times to make sure you are hashing the intended password, rather than a mistyped variant of it.

I could just make it prompt twice unconditionally, matching other utilities, but that would be a breaking change in a venerable old tool, so I added a flag to continue to the number of times it should prompt instead.