### PR TITLE
Update some TLD servers which reference Afilias

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -59,9 +59,9 @@
 .biz	whois.nic.biz
 .cat	whois.nic.cat
 .coop	whois.nic.coop
-.info	whois.afilias.net
+.info	whois.nic.info
 .jobs	whois.nic.jobs
-.mobi	whois.afilias.net
+.mobi	whois.nic.mobi
 .museum	whois.nic.museum
 .name	whois.nic.name
 .post	whois.dotpostregistry.net
@@ -159,7 +159,7 @@
 .gf	whois.mediaserv.net
 .gg	whois.gg
 .gh	whois.nic.gh
-.gi	whois2.afilias-grs.net
+.gi	whois.identitydigital.services
 .gl	whois.nic.gl
 .gm	WEB http://www.nic.gm/htmlpages/whois.htm
 .gn	whois.ande.gov.gn
@@ -216,7 +216,7 @@
 .ma	whois.registre.ma
 .mc	NONE	# www.nic.mc
 .md	whois.nic.md
-.me	whois.nic.me	# afilias
+.me	whois.nic.me	# identity digital (formerly afilias)
 #.mf
 .mg	whois.nic.mg
 .mh	NONE		# www.nic.net.mh


### PR DESCRIPTION
Afilias was bought by Donuts in 2020 and the combined entity is now called Identity Digital. I went through each entry that has 'afilias' in it to see if it needs updating. This covers ones that look straightforward: a sensible server name is in the IANA whois info, and it points to Identity Digital's catch-all server currently at 52.37.99.5 and 2600:1f13:101:c200:6a3:4cbe:e213:77ab

There are several more complicated cases that I left alone and will file tickets for.