### PR TITLE
Update .pr server to whois.nic.pr

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -261,7 +261,7 @@
 .pl	whois.dns.pl
 .pm	whois.nic.pm
 .pn	WEB http://www.pitcairn.pn/PnRegistry/whois.html
-.pr	whois.afilias-srs.net
+.pr	whois.nic.pr # identity digital
 .ps	whois.pnina.ps
 .pt	whois.dns.pt
 .pw	whois.nic.pw


### PR DESCRIPTION
Separate from https://github.com/rfc1036/whois/pull/176 as this one is a bit less clear-cut. The IANA info still lists whois.afilias-srs.net . However, as explained in #176, Afilias was bought in 2020 and the successor organization is named Identity Digital; they have already let one Afilias domain which hosted a whois server lapse (see #177) so the chances of this happening again seem non-zero, and it may be wise to change this.

whois.nic.pr , following the pretty common convention that a lot of other TLDs use, is set up and points to the same Identity Digital catch-all server that whois.afilias-srs.net currently points to, so it seems like a sensible choice (and one that the maintainer of the .pr TLD cannot lose control over).