### PR TITLE
Update `.ml` whois server

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -221,7 +221,7 @@
 .mg	whois.nic.mg
 .mh	NONE		# www.nic.net.mh
 .mk	whois.marnet.mk
-.ml	whois.nic.ml
+.ml	registre.nic.ml
 .mm	whois.registry.gov.mm
 .mn	whois.nic.mn
 .mo	WEB https://www.monic.mo/monic/faces/whois	# whois.monic.mo is restricted


### PR DESCRIPTION
This PR updates `whois.nic.ml:43` to `registre.nic.ml:43`. The retired `whois.nic.ml:43` server is no longer operational, likely due to the expiration of Zuurbier's contract on 17 July 2023, after which control was transferred back to the Malian government.