### PR TITLE
Add the .nyc.mn TLD server

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -223,6 +223,7 @@
 .mk	whois.marnet.mk
 .ml	whois.nic.ml
 .mm	whois.registry.gov.mm
+.nyc.mn whois.dot.nyc.mn
 .mn	whois.nic.mn
 .mo	WEB https://www.monic.mo/monic/faces/whois	# whois.monic.mo is restricted
 .mp	NONE		# get.mp


### PR DESCRIPTION
Sources:

- https://publicsuffix.org/list/public_suffix_list.dat
- https://dot.nyc.mn/

```
~# whois -h whois.dot.nyc.mn example.nyc.mn
# WHOIS Server
# Queried by: ****:****:****:****::1 (IPv6)
# Query: example.nyc.mn
# Time: 2025-05-10T04:43:10+00:00

Domain: example.nyc.mn
Status: free
```