### PR TITLE
Remove the .info and .mobi WHOIS servers

### DIFF
--- a/tld_serv_list
+++ b/tld_serv_list
@@ -59,13 +59,13 @@
 .biz	whois.nic.biz
 .cat	whois.nic.cat
 .coop	whois.nic.coop
-.info	RECURSIVE whois.nic.info	# whois.identitydigital.services
-.jobs	NONE
-.mobi	RECURSIVE whois.nic.mobi	# whois.identitydigital.services
+.info	WEB https://lookup.icann.org/
+.jobs	WEB https://lookup.icann.org/
+.mobi	WEB https://lookup.icann.org/
 .museum	whois.nic.museum
 .name	whois.nic.name
 .post	whois.nic.post
-.pro	NONE
+.pro	WEB https://lookup.icann.org/
 .tel	whois.nic.tel
 .travel	whois.nic.travel
 .xxx	whois.nic.xxx


### PR DESCRIPTION
They do not provide WHOIS data anymore. The only response is "TLD is not supported." IANA Root Zone Database no longer lists the WHOIS Server.