### PR TITLE
whois.c: remove unused variable 'sock'

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -1039,7 +1039,6 @@ char *query_server(const char *server, const char *port, const char *query)
 char *query_verisign(const char *server, const char *port, const char *query)
 {
     char *temp, *p;
-    int sock;
     char *referral_server = NULL;
     int dotscount = 0;
 


### PR DESCRIPTION
Remove unused variable 'sock' from `query_verisign()`.