### PR TITLE
query_server: strip control characters from server response

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -1005,8 +1005,15 @@ char *query_server(const char *server, const char *port, const char *query)
 	err_sys("write");
     free(temp);
 
-    while (fgets(buf, sizeof(buf), fi)) {
+	while (fgets(buf, sizeof(buf), fi)) {
 	if ((p = strpbrk(buf, "\r\n")))		/* remove the trailing CR/LF */
+	    *p = '\0';
+
+	/* strip terminal control characters to prevent escape sequence injection */
+	for (p = buf; *p; p++)
+	    if ((unsigned char)*p < 0x20 && *p != '\t')
+		*p = '?';
+	if ((p = strchr(buf, '\x7f')))
 	    *p = '\0';
 
 	if (referral_handler)


### PR DESCRIPTION
whois server responses are written directly to stdout without filtering terminal control characters. A malicious or compromised whois server can inject ANSI escape sequences (OSC 52 clipboard injection, terminal title manipulation, screen clearing) into the user's terminal.

Filter control characters (bytes < 0x20 except tab) and DEL (0x7F) from each response line before processing, replacing them with '?'.