### PR TITLE
openconn: cancel alarm after successful connection

### DIFF
--- a/whois.c
+++ b/whois.c
@@ -1132,6 +1132,7 @@ int openconn(const char *server, const char *port)
 	err_sys("connect");
 #endif
 
+    alarm(0);
     return fd;
 }
 


### PR DESCRIPTION
openconn() arms a 60-second alarm before DNS resolution and TCP connect, but never clears it after the connection succeeds. The timer persists through the entire response-reading loop in query_server(), causing premature timeout on slow connections or large whois responses.

Call alarm(0) before returning from openconn() so the alarm only covers connection establishment.